### PR TITLE
Fix typo in </p>

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
         Check out Beta Intl Boba Week! 👆 (click here)
       </div>
       <div class="additional-info" id="additional-info">
-        <p>For international participants, create a website and we will ship a small pack of dried boba to you that you can make it yourself! Running from 11/17 - 11/23 in Beta <./p>
+        <p>For international participants, create a website and we will ship a small pack of dried boba to you that you can make it yourself! Running from 11/17 - 11/23 in Beta </p>
       </div>
     </div>
     


### PR DESCRIPTION
Changes `<./p>` to `</p>`, fixing this error
![image](https://github.com/user-attachments/assets/311f796e-625f-42e7-ab2f-ebbf7ab2ffb4)