### PR TITLE
feat: open repo/demo link for submissions in new tab instead

### DIFF
--- a/gallery.js
+++ b/gallery.js
@@ -64,10 +64,10 @@ async function fetchData() {
         <div class="links">
           <a href="${
             submission.fields["Code URL"]
-          }" class="github-button"><i class="fa-brands fa-github"></i> Github</a>
+          }" class="github-button" target="_blank"><i class="fa-brands fa-github"></i> Github</a>
           <a href="${
             submission.fields["Playable URL"]
-          }" class="demo-button"><i class="fa-solid fa-link"></i> Demo</a>
+          }" class="demo-button" target="_blank"><i class="fa-solid fa-link"></i> Demo</a>
         </div>
       </div>
     `;


### PR DESCRIPTION
Adds target="_blank" to the github/demo links for submissions to open those in a new tab instead of in the current tab